### PR TITLE
fixed variable templating/interpolation for host_vars

### DIFF
--- a/action_plugins/serverdensity.py
+++ b/action_plugins/serverdensity.py
@@ -67,7 +67,7 @@ class ActionModule(object):
         vv('Ensure hosts...')
         for host in self.runner.host_set:
             vv('- ' + host)
-            host_vars = self.runner.inventory.get_variables(host)
+            host_vars = inject['hostvars'][host]
             facts = host_vars.get('ansible_facts', {})
             location = host_vars.get('location')
             if not location:


### PR DESCRIPTION
When trying to use templated variables for `sd_alerts` and other host variables the template wasn't expanded.

This PR fixes this by accessing the host_vars via `inject['hostvars'][host]` instead of `self.runner.inventory.get_variables(host)`.