### PR TITLE
catch KeyErrors in error formatter

### DIFF
--- a/action_plugins/serverdensity.py
+++ b/action_plugins/serverdensity.py
@@ -208,10 +208,13 @@ class ActionModule(object):
             msg = content['message']
             if content['errors']:
                 for error in content['errors']:
-                    if error['message']:
-                        msg += ' // ' + error['message']
-                    if error['description']:
-                        msg += ' // ' + error['description']
+                    try:
+                        if error['message']:
+                            msg += ' // ' + error['message']
+                        if error['description']:
+                            msg += ' // ' + error['description']
+                    except KeyError:
+                        continue
             raise ae('%s' % msg)
         return content
 


### PR DESCRIPTION
example of `content` that throws KeyError
```
content = {u'errors': [{u'subject': u'token', u'type': u'invalid_token'}],
 u'message': u'Invalid token'}
```

do we also want to add formatting of these other reply fields?
```
                    if defined(error['subject']):
                        msg += ' // ' + error['subject']
                    if defined(error['type']):
                        msg += ' // ' + error['type']
```